### PR TITLE
Generic queries

### DIFF
--- a/postgrest_py/_async/client.py
+++ b/postgrest_py/_async/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Dict, Union, cast
+from typing import Dict, Tuple, Type, TypeVar, Union, cast
 
 from deprecation import deprecated
 from httpx import Response, Timeout
+from pydantic import BaseModel
 
 from .. import __version__
 from ..base_client import (
@@ -12,7 +13,9 @@ from ..base_client import (
     BasePostgrestClient,
 )
 from ..utils import AsyncClient
-from .request_builder import AsyncRequestBuilder
+from .request_builder import AsyncRequestBuilder, _AsyncModelRequestBuilder
+
+_MT = TypeVar("_MT", bound=BaseModel)
 
 
 class AsyncPostgrestClient(BasePostgrestClient):
@@ -56,17 +59,37 @@ class AsyncPostgrestClient(BasePostgrestClient):
     async def aclose(self) -> None:
         await self.session.aclose()
 
-    def from_(self, table: str) -> AsyncRequestBuilder:
-        """Perform a table operation."""
+    def _pre_table_op(self, table_name: str) -> Tuple[AsyncClient, str]:
+        """Prepare the session and API route before a query."""
         base_url = str(self.session.base_url)
         headers = dict(self.session.headers.items())
         session = self.create_session(base_url, headers, self.session.timeout)
         session.auth = self.session.auth
+        return session, f"/{table_name}"
+
+    def from_(self, table: str) -> AsyncRequestBuilder:
+        """Perform a table operation."""
+        session, path = self._pre_table_op(table)
         return AsyncRequestBuilder(session, f"/{table}")
 
     def table(self, table: str) -> AsyncRequestBuilder:
         """Alias to self.from_()."""
         return self.from_(table)
+
+    def from_model(self, model: Type[_MT]) -> _AsyncModelRequestBuilder[_MT]:
+        """Perform a table operation, passing in a pydantic BaseModel.
+        The model will be used to parse the rows returned by the query.
+
+        Note:
+            The name of the table can be:
+            1) either the same as the name of the model
+            2) set as a ClassVar with the name __table_name__
+
+            If the class var is set, that will take priority.
+        """
+        table_name = getattr(model, "__table_name__", model.__name__)
+        session, path = self._pre_table_op(table_name)
+        return _AsyncModelRequestBuilder[model](session, path)
 
     @deprecated("0.2.0", "1.0.0", __version__, "Use self.from_() instead")
     def from_table(self, table: str) -> AsyncRequestBuilder:

--- a/postgrest_py/_async/request_builder.py
+++ b/postgrest_py/_async/request_builder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel, ValidationError
 
@@ -149,3 +149,127 @@ class AsyncRequestBuilder:
             returning=returning,
         )
         return AsyncFilterRequestBuilder(self.session, self.path, method, json)
+
+
+_T = TypeVar("_T", bound=BaseModel)
+
+# The following are replicas of the normal classes above
+# Their only purpose is to ensure type-safety and provide good
+# editor autocompletion, when using pydantic BaseModels with queries.
+
+
+class _AsyncModelQueryRequestBuilder(Generic[_T], AsyncQueryRequestBuilder):
+    async def execute(self) -> APIResponse[_T]:
+        # super().execute(model=_T) has NOT been used here
+        # as pyright was raising errors for it.
+        r = await self.session.request(
+            self.http_method,
+            self.path,
+            json=self.json,
+        )
+        try:
+            return APIResponse[_T].from_http_request_response(r)
+        except ValueError as e:
+            raise APIError(r.json()) from e
+
+
+class _AsyncModelFilterRequestBuilder(Generic[_T], BaseFilterRequestBuilder, _AsyncModelQueryRequestBuilder[_T]):  # type: ignore
+    def __init__(
+        self,
+        session: AsyncClient,
+        path: str,
+        http_method: str,
+        json: dict,
+    ) -> None:
+        BaseFilterRequestBuilder.__init__(self, session)
+        _AsyncModelQueryRequestBuilder[_T].__init__(
+            self, session, path, http_method, json
+        )
+
+
+class _AsyncModelSelectRequestBuilder(
+    BaseSelectRequestBuilder, _AsyncModelQueryRequestBuilder[_T]
+):
+    def __init__(
+        self,
+        session: AsyncClient,
+        path: str,
+        http_method: str,
+        json: dict,
+    ) -> None:
+        BaseSelectRequestBuilder.__init__(self, session)
+        _AsyncModelQueryRequestBuilder[_T].__init__(
+            self, session, path, http_method, json
+        )
+
+
+class _AsyncModelRequestBuilder(Generic[_T], AsyncRequestBuilder):
+    def select(
+        self,
+        *columns: str,
+        count: Optional[CountMethod] = None,
+    ) -> _AsyncModelSelectRequestBuilder[_T]:
+        method, json = pre_select(self.session, *columns, count=count)
+        return _AsyncModelSelectRequestBuilder[_T](self.session, self.path, method, json)
+
+    def insert(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+        upsert: bool = False,
+    ) -> _AsyncModelQueryRequestBuilder[_T]:
+        method, json = pre_insert(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+            upsert=upsert,
+        )
+        return _AsyncModelQueryRequestBuilder[_T](self.session, self.path, method, json)
+
+    def upsert(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+        ignore_duplicates: bool = False,
+    ) -> _AsyncModelQueryRequestBuilder[_T]:
+        method, json = pre_upsert(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+            ignore_duplicates=ignore_duplicates,
+        )
+        return _AsyncModelQueryRequestBuilder[_T](self.session, self.path, method, json)
+
+    def update(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+    ) -> _AsyncModelFilterRequestBuilder[_T]:
+        method, json = pre_update(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+        )
+        return _AsyncModelFilterRequestBuilder[_T](self.session, self.path, method, json)
+
+    def delete(
+        self,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+    ) -> _AsyncModelFilterRequestBuilder[_T]:
+        method, json = pre_delete(
+            self.session,
+            count=count,
+            returning=returning,
+        )
+        return _AsyncModelFilterRequestBuilder[_T](self.session, self.path, method, json)

--- a/postgrest_py/_async/request_builder.py
+++ b/postgrest_py/_async/request_builder.py
@@ -173,7 +173,7 @@ class _AsyncModelQueryRequestBuilder(Generic[_T], AsyncQueryRequestBuilder):
             raise APIError(r.json()) from e
 
 
-class _AsyncModelFilterRequestBuilder(Generic[_T], BaseFilterRequestBuilder, _AsyncModelQueryRequestBuilder[_T]):  # type: ignore
+class _AsyncModelFilterRequestBuilder(BaseFilterRequestBuilder, _AsyncModelQueryRequestBuilder[_T]):  # type: ignore
     def __init__(
         self,
         session: AsyncClient,

--- a/postgrest_py/_sync/client.py
+++ b/postgrest_py/_sync/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Dict, Union, cast
+from typing import Dict, Tuple, Type, TypeVar, Union, cast
 
 from deprecation import deprecated
 from httpx import Response, Timeout
+from pydantic import BaseModel
 
 from .. import __version__
 from ..base_client import (
@@ -12,7 +13,9 @@ from ..base_client import (
     BasePostgrestClient,
 )
 from ..utils import SyncClient
-from .request_builder import SyncRequestBuilder
+from .request_builder import SyncRequestBuilder, _SyncModelRequestBuilder
+
+_MT = TypeVar("_MT", bound=BaseModel)
 
 
 class SyncPostgrestClient(BasePostgrestClient):
@@ -56,17 +59,37 @@ class SyncPostgrestClient(BasePostgrestClient):
     def aclose(self) -> None:
         self.session.aclose()
 
-    def from_(self, table: str) -> SyncRequestBuilder:
-        """Perform a table operation."""
+    def _pre_table_op(self, table_name: str) -> Tuple[SyncClient, str]:
+        """Prepare the session and API route before a query."""
         base_url = str(self.session.base_url)
         headers = dict(self.session.headers.items())
         session = self.create_session(base_url, headers, self.session.timeout)
         session.auth = self.session.auth
-        return SyncRequestBuilder(session, f"/{table}")
+        return session, f"/{table_name}"
+
+    def from_(self, table: str) -> SyncRequestBuilder:
+        """Perform a table operation."""
+        session, path = self._pre_table_op(table)
+        return SyncRequestBuilder(session, path)
 
     def table(self, table: str) -> SyncRequestBuilder:
         """Alias to self.from_()."""
         return self.from_(table)
+
+    def from_model(self, model: Type[_MT]) -> _SyncModelRequestBuilder[_MT]:
+        """Perform a table operation, passing in a pydantic BaseModel.
+        The model will be used to parse the rows returned by the query.
+
+        Note:
+            The name of the table can be:
+            1) either the same as the name of the model
+            2) set as a ClassVar with the name __table_name__
+
+            If the class var is set, that will take priority.
+        """
+        table_name = getattr(model, "__table_name__", model.__name__)
+        session, path = self._pre_table_op(table_name)
+        return _SyncModelRequestBuilder[_MT](session, path)
 
     @deprecated("0.2.0", "1.0.0", __version__, "Use self.from_() instead")
     def from_table(self, table: str) -> SyncRequestBuilder:

--- a/postgrest_py/_sync/request_builder.py
+++ b/postgrest_py/_sync/request_builder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -149,3 +149,123 @@ class SyncRequestBuilder:
             returning=returning,
         )
         return SyncFilterRequestBuilder(self.session, self.path, method, json)
+
+
+_T = TypeVar("_T", bound=BaseModel)
+
+# The following are replicas of the normal classes above
+# Their only purpose is to ensure type-safety and provide good
+# editor autocompletion, when using pydantic BaseModels with queries.
+
+
+class _SyncModelQueryRequestBuilder(Generic[_T], SyncQueryRequestBuilder):
+    def execute(self) -> APIResponse[_T]:
+        # super().execute(model=_T) has NOT been used here
+        # as pyright was raising errors for it.
+        r = self.session.request(
+            self.http_method,
+            self.path,
+            json=self.json,
+        )
+        try:
+            return APIResponse[_T].from_http_request_response(r)
+        except ValueError as e:
+            raise APIError(r.json()) from e
+
+
+class _SyncModelFilterRequestBuilder(Generic[_T], BaseFilterRequestBuilder, _SyncModelQueryRequestBuilder[_T]):  # type: ignore
+    def __init__(
+        self,
+        session: SyncClient,
+        path: str,
+        http_method: str,
+        json: dict,
+    ) -> None:
+        BaseFilterRequestBuilder.__init__(self, session)
+        _SyncModelQueryRequestBuilder[_T].__init__(self, session, path, http_method, json)
+
+
+class _SyncModelSelectRequestBuilder(
+    BaseSelectRequestBuilder, _SyncModelQueryRequestBuilder[_T]
+):
+    def __init__(
+        self,
+        session: SyncClient,
+        path: str,
+        http_method: str,
+        json: dict,
+    ) -> None:
+        BaseSelectRequestBuilder.__init__(self, session)
+        _SyncModelQueryRequestBuilder[_T].__init__(self, session, path, http_method, json)
+
+
+class _SyncModelRequestBuilder(Generic[_T], SyncRequestBuilder):
+    def select(
+        self,
+        *columns: str,
+        count: Optional[CountMethod] = None,
+    ) -> _SyncModelSelectRequestBuilder[_T]:
+        method, json = pre_select(self.session, *columns, count=count)
+        return _SyncModelSelectRequestBuilder[_T](self.session, self.path, method, json)
+
+    def insert(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+        upsert: bool = False,
+    ) -> _SyncModelQueryRequestBuilder[_T]:
+        method, json = pre_insert(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+            upsert=upsert,
+        )
+        return _SyncModelQueryRequestBuilder[_T](self.session, self.path, method, json)
+
+    def upsert(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+        ignore_duplicates: bool = False,
+    ) -> _SyncModelQueryRequestBuilder[_T]:
+        method, json = pre_upsert(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+            ignore_duplicates=ignore_duplicates,
+        )
+        return _SyncModelQueryRequestBuilder[_T](self.session, self.path, method, json)
+
+    def update(
+        self,
+        json: dict,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+    ) -> _SyncModelFilterRequestBuilder[_T]:
+        method, json = pre_update(
+            self.session,
+            json,
+            count=count,
+            returning=returning,
+        )
+        return _SyncModelFilterRequestBuilder[_T](self.session, self.path, method, json)
+
+    def delete(
+        self,
+        *,
+        count: Optional[CountMethod] = None,
+        returning: ReturnMethod = ReturnMethod.representation,
+    ) -> _SyncModelFilterRequestBuilder[_T]:
+        method, json = pre_delete(
+            self.session,
+            count=count,
+            returning=returning,
+        )
+        return _SyncModelFilterRequestBuilder[_T](self.session, self.path, method, json)

--- a/postgrest_py/_sync/request_builder.py
+++ b/postgrest_py/_sync/request_builder.py
@@ -173,7 +173,7 @@ class _SyncModelQueryRequestBuilder(Generic[_T], SyncQueryRequestBuilder):
             raise APIError(r.json()) from e
 
 
-class _SyncModelFilterRequestBuilder(Generic[_T], BaseFilterRequestBuilder, _SyncModelQueryRequestBuilder[_T]):  # type: ignore
+class _SyncModelFilterRequestBuilder(BaseFilterRequestBuilder, _SyncModelQueryRequestBuilder[_T]):  # type: ignore
     def __init__(
         self,
         session: SyncClient,


### PR DESCRIPTION
Adds support for:
```py
class Country(BaseModel):
    __table_name__: typing.ClassVar[str] = "countries"
    # fields follow

r = client.from_model(Country).select("*").execute()
reveal_type(r.data)  # Type is List[Country]
```
## More examples
```py
from typing import ClassVar, List, Optional
from datetime import datetime

from pydantic import BaseModel
from postgrest_py import SyncPostgrestClient

class City(BaseModel):
    id: Optional[int]
    created_at: Optional[datetime]
    country_id: Optional[int]
    city_name: Optional[str]

    # if this classvar is set on a model, that is used in queries instead of the model name
    __table_name__: ClassVar[str] = "cities"

class Country(BaseModel):
    id: Optional[int]
    created_at: Optional[datetime]
    country_name: Optional[str]
    capital: Optional[str]
    cities: Optional[List[City]]  # allows to use this model for joins between the tables

    __table_name__: ClassVar[str] = "countries"

client = SyncPostgrestClient(...)

r = client.from_("countries").select("*,cities(*)").execute()
reveal_type(r.data)  # Type is List[Dict[str, Any]], as no model was passed

# this will work for joins as well, as we have included the cities field in the Country model
r = client.from_("countries").select("*,cities(*)").execute(model=Country)
reveal_type(r.data)  # Type is List[Country]

r = client.from_model(Country).select("*,cities(*)").execute()
reveal_type(r.data)  # Type is List[Country]
```

Note that another model can **not** be passed to `.execute` if `client.from_model` is used (this is to make it play well with the type system; if anyone has any alternate implementation ideas please let me know!)
That is,
```py
client.from_model(Country).select("*").execute(model=FooBar)  # error!
```
## Pros
Works with the type system (tested with pyright)
Gets good editor autocompletion (tested on vscode)
![preview](https://kxrfsnhxqitzsegngyki.supabase.in/storage/v1/object/public/uploads/Code_Ay549wHJ1C.gif)

## Cons
Request builder classes had to be duplicated to make generic versions that would allow this. 

Please let me know if you have other ideas for implementing this feature!